### PR TITLE
docs: raw-data, parameter automation, low-level params, in-app tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,194 +1,54 @@
-# Raw Data
+# Clarius Research Tools
 
-This repository contains scripts and other code to read and process data collected from Clarius scanners. Each folder contains a specific project, and within includes sample data and matlab/python scripts to read, process, and display the data.
+This repository contains scripts and reference code to read and process data collected
+from Clarius scanners, plus documentation for the App's research features. Each folder
+holds a specific project with sample data and MATLAB/Python scripts to read, process, and
+display the data.
 
-Data that can be acquired from Clarius scanners include:
-* RF (raw radio frequency data)
-* IQ (quadrature data)
-* Envelope (B greyscale)
+Data that can be acquired from Clarius scanners includes:
 
-## Capture Modes
-* To enable raw data capture, the **Buffer** icon from the modes menu can be pressed. The scanner will then buffer raw data while imaging.
+- **RF** — raw radiofrequency data
+- **IQ** — quadrature data
+- **Envelope** — B-mode grayscale
 
-![Buffer Raw Data](blob/buffer.png)
-* To enable RF data collection, the **RF** icon from the modes menu can be pressed. The scanner will then engage internal RF frame capture while scanning in B mode.
+## Documentation
 
-![Buffer Raw Data](blob/rf.png)
-* IQ and envelope data is captured by default when RF mode is not engaged; RF and envelope data are captured by default when RF mode is engaged.
+- [In-App Research Tools](docs/in-app-tools.md) — capture raw data, stream RF, and emit
+  the hardware sync pulse from the Clarius App
+- [Raw Data Format](docs/raw-data-format.md) — package layout, the `.raw`/`.yml`/`.tgc`
+  formats, sample types, and how to read them in Python/MATLAB
+- [How Imaging Parameters Are Automated](docs/imaging-parameter-automation.md) — baseline
+  knowledge on how depth, preset, and probe drive transmit frequency, sampling, and gain
+- [Low-Level Parameters](docs/low-level-parameters.md) — the research parameters
+  accessible through the Cast and Solum APIs
 
-## RF Streaming
-* RF streaming is enabled by default when engaging RF mode, and can be toggled through the **Stream** icon.
+## Repository layout
 
-![Buffer Raw Data](blob/stream.png)
-* RF mode collects data within the region-of-interest (ROI) placed over the greyscale image.
-* While streaming is engaged, RF frames will be interleaved every 3 B/greyscale frames, and thus streamed at a lower frame rate than B. Buffering the RF data will also buffer at this rate.
-* When streaming is disabled, RF frames will be interleaved with every B/greyscale frame, thus increasing the frame rate, and affected by the buffering control only.
-* Streaming of RF data is used **only** for visualization within the App, therefore data streamed is not stored for further use; however when users connect to the scanner with the Cast API while RF is streaming, streaming of RF signals will automatically be routed to the API connected device.
-
-## Downloading Raw Data
-* Once imaging is frozen with raw data capture engaged, the capture image or capture cine buttons will automatically download the data from the scanner. Note that in all cases, a packaged .tar file is acquired which then uses an LZO compression scheme for further compressing the raw data. When data is accessed, users should ensure that the proper software to decompress the files is installed on their operating system.
-* Downloading raw data over the wireless link can take some time since the packages can be large; for a single frame capture, a download time of 1-3 seconds is typical, for cine captures, where hundreds of frames may be acquired, downloads may take up to one minute.
-* During the download, users must wait before imaging once again, progress is shown on the interface while this occurs.
-* The scanner is pre-configured with raw data buffers of specific sizes that the system can support to offer stable and consistent imaging, in most cases, up to 10 seconds of raw IQ and RF can be captured, and upwards of 20 seconds of raw B/envelope data. The App can store a cine of up to 30 seconds, it is important to note that the raw data downloaded will always correspond to the latest frames in time. For example, if the cine capture markers are placed at 0-10 seconds within a 20 second capture, it is possible that no raw data will actually be downloaded.
-
-### Accessing Raw Data
-
-Once an exam has been completed and submitted in the App, the raw data will be accessible through:
-* Clarius Cloud when viewing the exam online. Packaged .tar files can be downloaded directly from a browser.
-
-![Raw Data Download](blob/raw_cloud.png)
-* Exporting the exam to local mobile device storage can be done when ending the exam or through the Exams page. As of App version, 8.6, iOS is now supported to store non image data into the file system.
-
-![Raw Data Export](blob/save_device.png)
-* If the Cast API is available for the device, raw data can be downloaded via a custom C/C++ program in a similar format to the App, but with immediate access once downloaded from the scanner.
-
-## Raw Data Formats
-
-Once raw data files have been accessed onto a PC or other platform, the file structure will look similar to the following:
-- Grayscale/Doppler: raw_data.tar
-    - timestamp_env.raw.lzo -> timestamp_env.raw
-    - timestamp_env.yml
-    - timestamp_env.tgc.yml (if auto gain has been used)
-    - timestamp_iq.raw.lzo -> timestamp_iq.raw (note IQ will be Doppler data when color/power mode enabled)
-    - timestamp_iq.yml
-- RF Mode: raw_data.tar
-    - timestamp_env.raw.lzo -> timestamp_env.raw
-    - timestamp_env.tgc.yml (if auto gain has been used)
-    - timestamp_env.yml
-    - timestamp_rf.raw.lzo -> timestamp_rf.raw
-    - timestamp_rf.yml
-
-The .yml files (see YAML markup language definition) contain meta-information about the raw data collected, such as:
-* Frame Rates
-* Imaging Depth
-* Transmit Frequency
-* Focal Depth
-* Line and Sample Count
-* Frame Count
-
-The .tgc files (also in a YAML markup) contain meta-information about the TGC curves applied to each frame. As Clarius imaging defaults to automated TGC usage, each frame may be acquired with a slightly different analog gain curve in order to perform the task of gain adjustment for the user.
-
-The timestamps in the .tgc files will correlate to frame timestamps embedded in the raw data, for example:
 ```
-timestamp: 235855423246 { 7.00mm, 15.70dB }{ 21.00mm, 26.46dB }{ 35.00mm, 26.82dB }{ 49.00mm, 26.54dB }{ 63.00mm, 28.68dB }{ 77.00mm, 30.29dB }{ 91.00mm, 31.94dB }{ 105.00mm, 33.44dB }{ 119.00mm, 34.87dB }{ 133.00mm, 35.00dB }
+.
+├── common      shared readers (rdataread.py / rdataread.m)
+├── viewer      runnable examples (python / matlab / jupyter) + sample data
+└── docs        documentation
 ```
 
-The raw data must be decompressed from the .lzo files in the package. Once decompressed they can be open in any piece of software (MATLAB, Python, etc.) that is programmed with reading the file format.
+## Quick start
 
-Each .raw file uses the same format, which is:
-```
-Header
-Timestamp 0
-Data 0
-Timestamp 1
-Data 1
-...
-Timestamp N
-Data N
-```
-where the header is formatted as follows:
-```
-uint32 id
-uint32 numFrames
-uint32 numScanLines
-uint32 numSamplesPerLine
-uint32 sampleSizeInBytes
-```
-and each timestamp is in the format of:
-```
-uint64 timeInNanoSeconds
-```
-and each data block is of size (in bytes):
-```
-numScanLines * numSamplesPerLine * sampleSizeInBytes
-```
-and the corresponding file size will be:
-```
-sizeof(Header) + (numFrames * (sizeof(Timestamp) + (numScanLines * numSamplesPerLine * sampleSizeInBytes)))
+Read and display the bundled sample data:
+
+```bash
+cd viewer/python
+python runme.py
 ```
 
-### Data Type Formats
+The reader (`common/python/rdataread.py`) exposes `read_rf`, `read_iq`, and `read_env`;
+see [Raw Data Format](docs/raw-data-format.md) for the binary layout and conversion to
+B-mode.
 
-* B Mode data is always in 8-bit greyscale format that are pre scan-converted, meaning they are in ultrasound coordinates, and not pixel coordinates
-IQ data is always in 32-bit pairs of I and Q, where each I and Q sample is 16-bits. The demodulation frequency depends on the scanner and workflow, and may also vary on scanning parameters and depth.
+## Related repositories
 
-* RF data is always 16-bit beamformed samples, where Clarius digitizes natively at 60 MHz. Further down-sampling may be performed to ensure data can be captured, buffered, and transferred properly. At depths < 2cm, 60MHz sampling is applied; at 2 - 4cm, 30MHz sampling is applied; at depths > 4cm, 15 MHz sampling is applied.
-
-# Synchronization
-
-The probe has the ability to send a 3.3V CMOS signal from the pins on the rear. Pin 9 outputs the signal, with pins 5 and 8 being connected to ground - a diagram is shown below. One can use the HD3 fan CAD to design a custom connector that will attach to the rear of the probe and output the pulse through a custom BNC or something similar.
-
-To enable the signal output, open the research menu and press the **Sync** button (two circular arrows). The signal will be output at the start of each frame acquisition. Note that Clarius' ultrasound sequencing is semi-asynchronous with respect to frame acquisition, meaning the time between each frame will not be exactly the same, but generally within 1 millisecond.
-
-![Pin Output](blob/pins.png)
-
-The timing diagram below illustrates the relationship between sync pulse, transmit and receive.
-![Tx Rx Timing](blob/TxRx_timing.png)
-
-Below is a scope capture of the sync pulse which is a single ended 3.3V CMOS signal.
-![Sync Pulse](blob/sync_pulse.png)
-
-## Low Level Parameters
-
-The following is a non-exhaustive list of low level parameters that can be programmed through the Cast API
-
-### Floating Point Parameters
-
-Generic:
-- maxFrameRate: frame rate limit in Hz (0 - 100, where 0 is no limit)
-
-Greyscale:
-- txFreq: transmit frequency in MHz **
-- txFreqInv: transmit frequency in MHz for the inversion pulse **
-- txFn: transmit f-number **
-- txApt: maximum transmit aperture in elements (2 - 64) **
-- txFocus: focus depth in centimeters **
-- vpp: positive amplitude in volts (10 - 37) **
-- vnn: negative amplitude in volts (10 - 37) **
-- ceVpp: positive amplitude in volts for CEUS (10 - 37) **
-- ceVnn: negative amplitude in volts for CEUS (10 - 37) **
-- steer: image steering in degrees **
-- rxFn: receive f-number
-- rxFreqShallow: start demodulation frequency in MHz
-- rxFreqDeep: end demodulation frequency in MHz
-- speedOfSound: speed of sound correction in m/s
-- rfDecimation: decimation factor used for IQ data
-- envDecimation: decimation factor used for envelope/grayscale data
-- rfDecim: decimation factor of the RF signal acquisition
-- dyn: dynamic range in dB
-- nf: noise floor in dB
-
-Color/Power Doppler:
-- cfiPrf: pulse repetition frequency in kHz (range varies per probe/preset) **
-- cfiTxFreq: transmit frequency in MHz **
-- color steer: steering angle in degrees
-- cfiEnsemble: # of ensemble / transmits per line (6 - 16) **
-
-Pulsed Wave Doppler:
-- pwPrf: pulse repetition frequency in kHz (range varies per probe/preset) **
-- pwTxFreq: transmit frequency in MHz **
-- pw gate size: gate size in mm
-- pw steer: steering angle in degrees
-- pw angle correct: correction angle in degrees
-  
-### Boolean Parameters
-
-Greyscale:
-- sa: synthetic aperture
-- pih: pulse inversion harmonics
-- trapezoidal: extended field of view for linear probes
-
-### String Parameters
-
-Greyscale:
-- txPulseGen: transmit pulse **
-- txPulsePen: transmit pulse when pentetration mode is active **
-- txPulseInv: transmit pulse for the inversion pulse **
-
-Color/Power Doppler:
-- cfiPulse: transmit pulse **
-
-Pulsed Wave Doppler:
-- pwPulse: transmit pulse **
-
-** Notes that changing this parameter may alter the acoustic output of the transducers making the imaging operate outside of the safety parameters Clarius has programmed into the device
+- [clariusdev/cast](https://github.com/clariusdev/cast) — Cast API for real-time
+  streaming and raw-data download (App must be running)
+- [clariusdev/solum](https://github.com/clariusdev/solum) — Solum OEM SDK for direct
+  probe control and raw-data download
+- [clariusdev/texo](https://github.com/clariusdev/texo) — script-driven research imaging
+  (pre-release)

--- a/docs/imaging-parameter-automation.md
+++ b/docs/imaging-parameter-automation.md
@@ -1,0 +1,244 @@
+# How Imaging Parameters Are Automated
+
+A Clarius scanner is not a manual front-panel ultrasound machine. Most imaging parameters
+are **derived automatically** from three inputs — the **application** (preset) you select,
+the **probe** you have attached, and the **depth** you are imaging at — and re-optimized
+on the fly as you scan. This page explains that machinery so researchers understand *why*
+the numbers in their [raw-data metadata](raw-data-format.md) change from frame to frame,
+and what the [low-level parameters](low-level-parameters.md) are actually overriding.
+
+> **These scripts are internal.** End users never see or edit them — the Clarius App
+> resolves everything behind a simple depth control and a preset name. They are described
+> here only as *baseline conceptual knowledge* so researchers can interpret their captured
+> data. Researcher-facing scripting is coming separately through **texo** (see
+> [below](#loading-your-own-scripts-texo)), which exposes Clarius-defined,
+> research-targeted scripts — not the clinical-grade app scripts shown here.
+>
+> Examples use representative values from a C3 (curvilinear) probe. Exact coefficients
+> vary by probe and preset and evolve between software releases. The resolved value that
+> was actually used for any captured frame is always recorded in that frame's `.yml`.
+
+## The three inputs
+
+```mermaid
+flowchart LR
+  app[Application / preset] --> resolve
+  probe[Probe definition] --> resolve
+  depth[Imaging depth] --> resolve
+  resolve[Parameter resolution] --> seq[Transmit / receive sequence]
+  seq --> img[Optimized image]
+```
+
+- **Application** — what you're imaging (abdomen, cardiac, vascular, …). It selects which
+  groups of parameter scripts load and sets preset-specific offsets.
+- **Probe definition** — fixed physical and electrical properties of the transducer
+  (geometry, element count, frequency band, default depth, …).
+- **Depth** — the single most important *live* input. Changing depth re-derives transmit
+  frequency, focus, sampling/decimation, gain targets, and more.
+
+## Applications, depth regions, and parameter scripts
+
+An application is described by a `description.yml` that maps each supported probe to a
+depth control and one or more **depth regions**. Each region loads a named set of
+parameter scripts. Conceptually (abridged from the abdomen preset on a C3 probe):
+
+```yaml
+control:
+  - probe models: [ "C3*" ]
+    id: target depth
+    assign: endDepth          # the depth slider drives endDepth
+    units: cm
+    from: 3                    # slider range
+    to: 40
+    start: 15                  # default depth
+    scripts:
+      - from: 3                # depth region 3–30 cm
+        to: 30
+        parameters: [ "C3/gen", "C3/abd", "bf/curved", "dtgc",
+                      "enhance/abd", "user/base", "user/general", "modes/standard" ]
+      - from: 30               # depth region 30–40 cm
+        to: 40
+        parameters: [ "C3/gen", "C3/abd", "bf/curved", "dtgc", ... ]
+```
+
+Historically an application defined **several** depth regions, and crossing a region
+boundary swapped in a different group of scripts — a discrete re-optimization. Newer
+software has largely moved away from many discrete regions: a preset now tends to use a
+single region (or very few), and the optimization is instead **continuous** — driven by
+formulas that take depth as an input rather than by switching script sets. The region
+structure still exists internally, but most of the per-depth behavior now lives in the
+parameter expressions described below.
+
+The loaded scripts are layered: later files override earlier ones, and `user/base`
+provides the shared formulas every preset builds on.
+
+## Probe definitions and bounding frequencies
+
+Each probe ships a `definition.yml` describing its fixed properties. The parts that drive
+automation, for a C3HD3:
+
+```yaml
+geometry:   { type: curved, elements: 192, pitch: 300 microns, radius: 45 mm }
+capabilities: { tx: 64, rx: 32, rxClock: 60MHz, platform: v3 }
+stackinfo:  { lowFreq: 2MHz, centerFreq: 3.5MHz, upperFreq: 6MHz }   # transducer band
+defaults:   { depth: 10cm, dopplerFreq: 3MHz, compound angle: 7.5 degrees }
+freq:                                  # depth → transmit-frequency bounds
+  start depth: 1cm
+  end depth: 25cm
+  lowFreq: 2.5MHz
+  upperFreq: 5MHz
+```
+
+The `freq` block is the key to depth-based frequency selection: `upperFreq` is used at the
+shallow end, `lowFreq` at the deep end, with `start depth`/`end depth` defining the range
+over which the system slides between them. Parameter scripts reference these fields with a
+`{probe::...}` path, e.g. `{probe::freq::upperFreq}` or `{probe::geometry::elements}`.
+
+## Depth-driven transmit frequency (the "frequency slide")
+
+Higher frequencies give better resolution but attenuate faster; lower frequencies
+penetrate deeper. Rather than expose a frequency knob, the system slides transmit
+frequency with depth between the probe's bounding frequencies. From `user/base`:
+
+```yaml
+txSlideCoef: "max(0cm, min({endDepth}, {probe::freq::end depth}) - {probe::freq::start depth})
+              / ({probe::freq::end depth} - {probe::freq::start depth})"
+txSlideFreq: "{probe::freq::upperFreq} - ({txSlideCoef} * ({probe::freq::upperFreq} - {probe::freq::lowFreq}))"
+```
+
+- `txSlideCoef` runs from **0** (shallow) to **1** (deep) as imaging depth moves across
+  the probe's `freq` range.
+- `txSlideFreq` therefore interpolates from `upperFreq` (shallow → high resolution) down
+  to `lowFreq` (deep → better penetration).
+
+A preset then uses `txSlideFreq` as its transmit frequency, often with a small offset or a
+harmonic-imaging override. For the C3 general script:
+
+```yaml
+txFreq: "{thiMode} ? {thiFreq} : {txSlideFreq}"   # harmonic mode overrides the slide
+```
+
+So when a researcher reduces depth and sees the reported `transmit frequency` rise, that
+is the slide at work — not a separate setting.
+
+## Sampling rate and decimation follow depth
+
+Clarius digitizes natively at 60 MHz. Capturing, buffering, and wirelessly transferring
+data at full rate is only feasible for shallow imaging, so the **decimation factor**
+(how much the data is downsampled) grows with depth to keep each frame within a fixed
+native sample budget. From `user/base`:
+
+```yaml
+maxBufferNative: 2.5cm                                   # IQ/envelope budget (RF uses 4cm)
+safeDecimation:  "max(1, ceil({endDepth} / {maxBufferNative}))"
+adjustedDecimation: "({safeDecimation} >= 2 && {safeDecimation} < 3) ? 3 : {safeDecimation}"
+```
+
+The resolved decimation feeds the per-mode decimation parameters, e.g. in the C3 script
+`iqDecimation: "{adjustedDecimation}"` and `envDecimation: "{iqDecimation} + 5"`.
+
+The practical effect: **the deeper you image, the lower the effective sample rate** of the
+data you capture (effective rate ≈ 60 MHz ÷ decimation). For RF specifically this works
+out to roughly:
+
+| Depth | RF sampling |
+|-------|-------------|
+| < 2 cm | 60 MHz |
+| 2–4 cm | 30 MHz |
+| > 4 cm | 15 MHz |
+
+Always read the actual `sampling rate` (and `size` / `delay samples`) from each frame's
+`.yml` rather than assuming a fixed rate — see [raw-data-format.md](raw-data-format.md).
+
+## Auto focus
+
+By default the transmit focus is placed automatically at the middle of the imaging range:
+
+```yaml
+autoFocus: true
+autoFocusDepth: "{b start depth} + (({b end depth} - {b start depth}) / 2)"
+txFocus: "{autoFocus} ? {autoFocusDepth} : {manualFocusDepth}"
+```
+
+Turning auto focus off (a standard parameter) lets a fixed focal depth be used instead.
+
+## Auto gain and TGC
+
+Time-gain compensation (TGC) corrects for depth-dependent attenuation so tissue looks
+uniformly bright. **Auto gain is enabled by default for many applications** and drives the
+gain curve toward a target brightness automatically, which is why captured frames can each
+carry a slightly different TGC curve (recorded per frame in the `.tgc.yml`, see
+[raw-data-format.md](raw-data-format.md#tgcyml-per-frame-tgc)).
+
+- In **v12**, auto gain adjusted the **analog** TGC (the receive amplifier gain over
+  depth).
+- In the **latest** software, auto gain adjusts the **digital** TGC gain instead (applied
+  in processing). The analog front-end gain is set more conservatively, and the per-depth
+  digital offsets come from a script such as `dtgc` (digital-TGC offset points) combined
+  with an `autoGainTarget` brightness goal:
+
+```yaml
+autoGainTarget: "20dB + {tgcOffsetAg}"   # brightness the auto-gain loop aims for
+```
+
+Because of this difference, TGC curves and brightness behavior captured under v12 are not
+directly comparable to those captured under the latest software.
+
+## How the parameter expressions work
+
+The scripts are evaluated expressions, not static values. You won't edit the clinical
+scripts, but the same expression language underlies the research-targeted scripts you'll
+load through [texo](#loading-your-own-scripts-texo), so the conventions are worth knowing:
+
+- **References**: `{name}` pulls another parameter; `{probe::section::field}` pulls a
+  field from the probe `definition.yml` (e.g. `{probe::freq::lowFreq}`).
+- **Units are first-class**: `2.5MHz`, `40mm`, `15dB`, `20Hz`, `7.5 degrees`. Arithmetic
+  respects them.
+- **Conditionals**: ternaries like `"{penetrationMode} ? 35V : 30V"` choose values from
+  state flags.
+- **Layering**: later scripts in a region's list override earlier ones; presets adjust
+  shared `user/base` formulas through offsets (e.g. `tgcOffset`, `dynRangeOffset`).
+
+This is why two researchers on the same probe and preset can get different transmit
+frequencies, decimation, and gain simply by imaging at different depths — the system
+resolved a different set of values for each.
+
+## Loading your own scripts (texo)
+
+> 🚧 **Coming soon.** This section is a forward-looking summary; the texo tooling and its
+> repository are not published yet.
+
+The automation above describes the **clinical-grade** scripts that drive the Clarius App —
+these are not editable and not exposed to users. For researchers who want direct control
+over the transmit/receive sequence, Clarius is releasing **texo**: software that can load
+scripts to define imaging behavior at a low level.
+
+What to expect:
+
+- **Research-targeted scripts, not clinical scripts.** texo runs scripts that Clarius
+  defines and targets specifically for research use. The clinical app presets shown on
+  this page are not loaded into texo.
+- **The same expression model.** Scripts use the parameter expression language and
+  `{probe::...}` definitions described above, so the concepts here carry over directly.
+- **You drive the sequence.** Rather than relying on depth-based automation, a texo script
+  fixes the parameters you specify — frequency, focus, aperture, decimation, pulse shape,
+  and so on — which is what most acoustic and beamforming research needs.
+
+The same safety considerations as the [low-level parameters](low-level-parameters.md)
+apply: scripts can drive the transducer outside the optimized, validated operating points,
+so use appropriate test equipment and stay within your regulatory obligations.
+
+Documentation for texo lives in its own repository:
+[clariusdev/texo](https://github.com/clariusdev/texo) (pre-release).
+
+## What this means for research
+
+- **Read the metadata per frame.** Frequency, focal depth, sampling rate, decimation, and
+  TGC are all consequences of depth and preset and are recorded in each `.yml`/`.tgc.yml`.
+  Don't assume they're constant across a capture or between captures.
+- **Hold depth fixed** if you need consistent acquisition settings across frames or
+  sessions, since depth drives so much of the automation.
+- **Override deliberately.** To pin frequency, decimation, gain, focus, or pulse shape to
+  fixed values, use the [low-level parameters](low-level-parameters.md) through the Cast
+  or Solum APIs — keeping the safety warnings on that page in mind, since you are stepping
+  outside the optimized, validated presets.

--- a/docs/in-app-tools.md
+++ b/docs/in-app-tools.md
@@ -1,0 +1,96 @@
+# In-App Research Tools
+
+The Clarius App exposes research features for capturing raw data, streaming RF, and
+emitting a hardware sync pulse. This page covers how to drive them from the App. For the
+on-disk format of what you capture, see [raw-data-format.md](raw-data-format.md); for
+programmatic low-level control, see [low-level-parameters.md](low-level-parameters.md).
+
+## Capture modes
+
+Raw data capture is toggled from the **modes menu**:
+
+- **Buffer** — press the Buffer icon to have the scanner buffer raw data while imaging.
+
+  ![Buffer Raw Data](../blob/buffer.png)
+
+- **RF** — press the RF icon to engage internal RF frame capture while scanning in B
+  mode. RF data is collected within the region-of-interest (ROI) placed over the
+  grayscale image.
+
+  ![RF Mode](../blob/rf.png)
+
+What gets captured depends on whether RF mode is engaged:
+
+- **RF off:** IQ and envelope data are captured by default.
+- **RF on:** RF and envelope data are captured by default.
+
+## RF streaming
+
+RF streaming is enabled by default when RF mode is engaged, and is toggled with the
+**Stream** icon.
+
+![RF Stream](../blob/stream.png)
+
+- While streaming is **on**, RF frames are interleaved every 3 B/grayscale frames, so RF
+  streams (and buffers) at a lower frame rate than B.
+- While streaming is **off**, RF frames are interleaved with *every* B frame, increasing
+  the RF frame rate; capture is then governed by the buffering control only.
+- Streamed RF is used **only** for visualization in the App and is not stored. However,
+  if a client connects with the [Cast API](https://github.com/clariusdev/cast) while RF
+  is streaming, the RF signals are automatically routed to that client.
+
+## Downloading captured data
+
+Once imaging is **frozen** with raw-data capture engaged, the capture-image or
+capture-cine buttons automatically download the data from the scanner.
+
+- Data is always packaged as a `.tar` using LZO compression internally. Ensure your OS
+  has the right tools to decompress it (see [raw-data-format.md](raw-data-format.md)).
+- Downloads over the wireless link take time: ~1–3 s for a single frame; up to a minute
+  for cines of hundreds of frames. Wait for the on-screen progress to complete before
+  imaging again.
+- Buffers are sized for stable imaging: typically up to **10 s** of raw IQ/RF and up to
+  **20 s** of raw envelope. The App can store a cine of up to **30 s**.
+- **The downloaded raw data always corresponds to the latest frames in time.** If your
+  cine markers select an early window (e.g. 0–10 s of a 20 s capture), it's possible no
+  raw data is downloaded for that window.
+
+## Accessing captured data
+
+Once an exam is completed and submitted, raw data can be accessed via:
+
+- **Clarius Cloud** — view the exam online and download the packaged `.tar` directly from
+  a browser.
+
+  ![Raw Data Download](../blob/raw_cloud.png)
+
+- **Local export** — export the exam to device storage when ending the exam or from the
+  Exams page. (As of App v8.6, iOS can also store non-image data to the file system.)
+
+  ![Raw Data Export](../blob/save_device.png)
+
+- **Cast API** — if available for the device, raw data can be downloaded by a custom
+  C/C++ program with immediate access once it comes off the scanner. See the
+  [Cast API raw data flow](https://github.com/clariusdev/cast/blob/master/docs/getting-started.md#6-capture-raw-data).
+
+## Hardware sync output
+
+The probe can emit a **3.3 V CMOS** sync signal from the pins on its rear, marking the
+start of each frame acquisition. Pin 9 outputs the signal; pins 5 and 8 are ground. The
+HD3 fan CAD can be used as a basis for a custom connector that routes the pulse to a BNC.
+
+To enable it, open the **research menu** and press the **Sync** button (two circular
+arrows). The signal is output at the start of each frame.
+
+> Clarius' ultrasound sequencing is semi-asynchronous with respect to frame acquisition:
+> the interval between frames is not exactly constant, but is generally within 1 ms.
+
+![Pin Output](../blob/pins.png)
+
+The transmit/receive timing relationship:
+
+![Tx Rx Timing](../blob/TxRx_timing.png)
+
+A scope capture of the single-ended 3.3 V CMOS sync pulse:
+
+![Sync Pulse](../blob/sync_pulse.png)

--- a/docs/low-level-parameters.md
+++ b/docs/low-level-parameters.md
@@ -1,0 +1,118 @@
+# Low-Level Parameters
+
+Beyond the standard imaging controls (depth, gain, PRF, …), Clarius scanners expose a set
+of **low-level parameters** for fine acoustic and signal-processing control. They are
+intended for research and device bring-up.
+
+> ⚠️ **Safety.** These parameters bypass the optimized presets that the App and SDKs
+> normally manage for you. Changing them can alter the **acoustic output** of the
+> transducer and push imaging **outside the safety limits Clarius validates**, degrade
+> image quality, or destabilize the system. Parameters marked **\*\*** directly affect
+> acoustic output. Use appropriate test equipment and stay within your regulatory
+> obligations. Separate licensing may be required.
+
+## How to set them
+
+The same parameter set is reachable from both research-facing APIs:
+
+**Cast API** ([clariusdev/cast](https://github.com/clariusdev/cast)) — requires the
+Clarius App running and connected:
+
+```c
+castSetParameter("txFreq", 5.0, returnFn);    // numeric
+castEnableParameter("sa", 1, returnFn);       // boolean
+castSetPulse("txPulseGen", "+-", returnFn);   // transmit pulse shape
+```
+
+**Solum SDK** ([clariusdev/solum](https://github.com/clariusdev/solum)) — connects to the
+probe directly (OEM):
+
+```c
+solumSetLowLevelParam("txFreq", 5.0);
+solumEnableLowLevelParam("sa", 1);
+solumSetLowLevelPulse("txPulseGen", "+-");
+double v = solumGetLowLevelParam("txFreq");   // booleans read back as 0/1
+```
+
+Parameter names and semantics are identical across both. The lists below are the
+supported, publicly accessible low-level parameters; they are not exhaustive of every
+internal sequencing knob, and ranges vary by probe and preset.
+
+## Numeric parameters
+
+### Generic
+
+| Parameter | Meaning |
+|-----------|---------|
+| `maxFrameRate` | Frame-rate limit in Hz (0–100, `0` = no limit). |
+
+### Greyscale
+
+| Parameter | Meaning |
+|-----------|---------|
+| `txFreq` ** | Transmit frequency (MHz). |
+| `txFreqInv` ** | Transmit frequency for the inversion pulse (MHz). |
+| `txFn` ** | Transmit f-number. |
+| `txApt` ** | Maximum transmit aperture in elements (2–64). |
+| `txFocus` ** | Focus depth (cm). |
+| `vpp` ** | Positive amplitude (V, 10–37). |
+| `vnn` ** | Negative amplitude (V, 10–37). |
+| `ceVpp` ** | Positive amplitude for CEUS (V, 10–37). |
+| `ceVnn` ** | Negative amplitude for CEUS (V, 10–37). |
+| `steer` ** | Image steering (degrees). |
+| `rxFn` | Receive f-number. |
+| `rxFreqShallow` | Start demodulation frequency (MHz). |
+| `rxFreqDeep` | End demodulation frequency (MHz). |
+| `speedOfSound` | Speed-of-sound correction (m/s). |
+| `rfDecimation` | Decimation factor used for IQ data. |
+| `envDecimation` | Decimation factor used for envelope/grayscale data. |
+| `rfDecim` | Decimation factor of the RF signal acquisition. |
+| `dyn` | Dynamic range (dB). |
+| `nf` | Noise floor (dB). |
+
+### Color / Power Doppler
+
+| Parameter | Meaning |
+|-----------|---------|
+| `cfiPrf` ** | Pulse repetition frequency (kHz; range varies per probe/preset). |
+| `cfiTxFreq` ** | Transmit frequency (MHz). |
+| `color steer` | Steering angle (degrees). |
+| `cfiEnsemble` ** | Ensemble / transmits per line (6–16). |
+
+### Pulsed-Wave Doppler
+
+| Parameter | Meaning |
+|-----------|---------|
+| `pwPrf` ** | Pulse repetition frequency (kHz; range varies per probe/preset). |
+| `pwTxFreq` ** | Transmit frequency (MHz). |
+| `pw gate size` | Gate size (mm). |
+| `pw steer` | Steering angle (degrees). |
+| `pw angle correct` | Correction angle (degrees). |
+
+## Boolean parameters
+
+### Greyscale
+
+| Parameter | Meaning |
+|-----------|---------|
+| `sa` | Synthetic aperture. |
+| `pih` | Pulse-inversion harmonics. |
+| `trapezoidal` | Extended field of view for linear probes. |
+
+## Pulse-shape (string) parameters
+
+Set with `castSetPulse` / `solumSetLowLevelPulse`. The shape string encodes the transmit
+waveform (e.g. `+-`, `+-+-+-+-`).
+
+| Parameter | Meaning |
+|-----------|---------|
+| `txPulseGen` ** | Transmit pulse. |
+| `txPulsePen` ** | Transmit pulse when penetration mode is active. |
+| `txPulseInv` ** | Transmit pulse for the inversion pulse. |
+| `cfiPulse` ** | Color/power transmit pulse. |
+| `pwPulse` ** | PW transmit pulse. |
+
+---
+
+** Changing this parameter may alter the acoustic output of the transducer, making
+imaging operate outside the safety parameters Clarius has programmed into the device.

--- a/docs/raw-data-format.md
+++ b/docs/raw-data-format.md
@@ -1,0 +1,177 @@
+# Raw Data Format
+
+How Clarius raw data is packaged on disk, the binary layout of each `.raw` file, the
+metadata that accompanies it, and how to read it in Python or MATLAB. For how to *capture*
+the data, see [in-app-tools.md](in-app-tools.md).
+
+Clarius scanners can produce three kinds of raw data:
+
+- **RF** — raw radiofrequency, 16-bit beamformed samples
+- **IQ** — quadrature data, interleaved 16-bit I and Q
+- **Envelope** — B-mode grayscale, 8-bit, pre-scan-converted (ultrasound coordinates)
+
+## Package layout
+
+Accessed data arrives as a `.tar` package; each raw stream inside is LZO-compressed
+(`.lzo`). Decompress with any LZO tool before reading. After extraction:
+
+```
+raw_data.tar
+├── <timestamp>_env.raw[.lzo]   envelope / B grayscale
+├── <timestamp>_env.yml         envelope metadata
+├── <timestamp>_env.tgc.yml     per-frame TGC (present if auto gain was used)
+├── <timestamp>_iq.raw[.lzo]    IQ (Doppler data when color/power mode is on)
+├── <timestamp>_iq.yml          IQ metadata
+├── <timestamp>_rf.raw[.lzo]    RF (RF mode only)
+├── <timestamp>_rf.yml          RF metadata
+└── <timestamp>_rf.tgc.yml      per-frame TGC for RF (if auto gain was used)
+```
+
+In a grayscale/Doppler capture you get `env` + `iq`; in RF mode you get `env` + `rf`.
+
+## `.raw` binary layout
+
+Every `.raw` file uses the same structure: a header, then a timestamp + data block per
+frame.
+
+```
+Header
+Timestamp 0
+Data 0
+Timestamp 1
+Data 1
+...
+Timestamp N
+Data N
+```
+
+The header is five little-endian `uint32` fields:
+
+```
+uint32 id
+uint32 numFrames
+uint32 numScanLines
+uint32 numSamplesPerLine
+uint32 sampleSizeInBytes
+```
+
+Each timestamp is a little-endian `uint64` in nanoseconds:
+
+```
+uint64 timeInNanoSeconds
+```
+
+Each data block is `numScanLines * numSamplesPerLine * sampleSizeInBytes` bytes, so the
+total file size is:
+
+```
+sizeof(Header) + numFrames * (sizeof(Timestamp) + numScanLines * numSamplesPerLine * sampleSizeInBytes)
+```
+
+## Sample formats
+
+| Type | Sample | Notes |
+|------|--------|-------|
+| **Envelope (B)** | 8-bit grayscale | Pre-scan-converted (ultrasound, not pixel, coordinates). |
+| **IQ** | 32-bit pairs (16-bit I + 16-bit Q) | Demodulation frequency depends on scanner/workflow and may vary with depth and parameters. In a `.raw` row the I and Q samples are interleaved (`I,Q,I,Q,…`). |
+| **RF** | 16-bit beamformed | Clarius digitizes natively at 60 MHz; the stored sampling rate is reported in the `.yml`. |
+
+RF sampling adapts to depth so the data can be captured, buffered, and transferred:
+
+| Depth | RF sampling |
+|-------|-------------|
+| < 2 cm | 60 MHz |
+| 2–4 cm | 30 MHz |
+| > 4 cm | 15 MHz |
+
+## `.yml` metadata
+
+Each `.raw` has a sibling `.yml` describing acquisition. Example (RF):
+
+```yaml
+frames: 13
+frame rate: 11 Hz
+transmit frequency: 10 MHz
+imaging depth: 40 mm
+focal depth: 20 mm
+tgc: { 0.00mm, 30.00dB }{ 40.00mm, 35.00dB }
+size: {samples per line: 3120, number of lines: 192, sample size: 2 bytes}
+type: RF
+compression: none
+sampling rate: 60 MHz
+delay samples: 62
+lines:
+  - {rx element: 0, tx element: 1.5, angle: 0 °}
+  - {rx element: 1, tx element: 1.5, angle: 0 °}
+  ...
+```
+
+Key fields:
+
+| Field | Meaning |
+|-------|---------|
+| `frames` | Number of frames in the `.raw`. |
+| `frame rate` | Acquisition frame rate. |
+| `transmit frequency` | Transmit center frequency. |
+| `imaging depth` | Imaging depth. |
+| `focal depth` | Transmit focal depth. |
+| `tgc` | Depth/gain points of the nominal TGC curve. |
+| `size` | `samples per line`, `number of lines`, `sample size` (bytes) — mirrors the `.raw` header. |
+| `type` | `RF`, `IQ`, or `envelope`. |
+| `compression` | Compression of the samples (`none` once decompressed). |
+| `sampling rate` | Sample rate of the acquired data (see RF table above). |
+| `delay samples` | Leading samples before the first valid sample (acquisition delay). |
+| `lines` | Per-line geometry: receive element, transmit element, and steering angle. Use it to map scan lines to aperture positions. |
+
+### `.tgc.yml` per-frame TGC
+
+Because Clarius defaults to **automated** TGC, each frame can be acquired with a slightly
+different analog gain curve. The `.tgc.yml` records the curve applied to each frame, keyed
+by the frame timestamp that matches the `.raw` timestamps:
+
+```
+timestamp: 235855423246 { 7.00mm, 15.70dB }{ 21.00mm, 26.46dB }{ 35.00mm, 26.82dB } ...
+```
+
+It is only present when auto gain (auto TGC) was active during the capture.
+
+## Reading the data
+
+This repo ships reference readers and runnable examples:
+
+- [`common/python/rdataread.py`](../common/python/rdataread.py) — `read_rf`, `read_iq`,
+  `read_env`
+- [`common/matlab/rdataread.m`](../common/matlab/rdataread.m) — MATLAB equivalents
+- [`viewer/python/runme.py`](../viewer/python/runme.py),
+  [`viewer/matlab/runme.m`](../viewer/matlab/runme.m),
+  [`viewer/jupyter/runme.ipynb`](../viewer/jupyter/runme.ipynb) — load and display the
+  bundled sample data in [`viewer/data`](../viewer/data)
+
+### Python: read and convert to B
+
+The reader parses the header, then each timestamp + frame into a
+`lines × samples × frames` array (IQ has `samples * 2` columns: interleaved I/Q).
+
+```python
+import numpy as np
+from scipy.signal import hilbert
+import rdataread as rd
+
+# RF -> B (envelope detection + log compression)
+hdr, timestamps, data = rd.read_rf("phantom_rf.raw")
+b = 20 * np.log10(np.abs(1 + hilbert(data[:, :, 0])))
+
+# IQ -> B (magnitude + log compression)
+hdr, timestamps, data = rd.read_iq("phantom_iq.raw")
+i, q = data[:, 0::2, :], data[:, 1::2, :]
+b = 10 * np.log10(1 + i[:, :, 0] ** 2 + q[:, :, 0] ** 2)
+
+# Envelope is already 8-bit B data
+hdr, timestamps, data = rd.read_env("phantom_env.raw")
+```
+
+See [`viewer/python/runme.py`](../viewer/python/runme.py) for the full display pipeline
+(RF, IQ, and envelope frames side by side).
+
+> Remember the data is in ultrasound (polar/array) coordinates — scan conversion to pixel
+> space is up to you and depends on the probe geometry reported in the `.yml`.


### PR DESCRIPTION
Adds a `docs/` folder and trims the README to a landing page:
- raw-data-format.md — package layout, .raw/.yml/.tgc formats, Python/MATLAB readers
- in-app-tools.md — buffer/RF/stream modes, downloading, sync pulse
- imaging-parameter-automation.md — how depth/preset/probe drive frequency, sampling, gain
- low-level-parameters.md — research parameters via Cast and Solum